### PR TITLE
Makefile fixes and building for darwin/arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ builds:
     - goos: darwin
       goarch: '386'
     - goos: darwin
-      goarch: arm64
+      goarch: arm
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-HOSTNAME=kentik.com
-NAMESPACE=automation
-NAME=kentik-cloudexport
-BINARY=terraform-provider-${NAME}
-VERSION=0.1.0
-OS_ARCH=linux_amd64
+HOSTNAME = kentik
+NAMESPACE = automation
+NAME = kentik-cloudexport
+BINARY = terraform-provider-${NAME}
+VERSION := $(shell echo `git tag --list 'v*' | tail -1 | cut -d v -f 2`)
+OS_ARCH := $(shell printf "%s_%s" `go env GOHOSTOS` `go env GOHOSTARCH`)
 
 # apiserver address for the provider under test to talk to (for testing purposes)
 APISERVER_ADDR=localhost:9955

--- a/examples/data-sources/kentik-cloudexport_item/provider.tf
+++ b/examples/data-sources/kentik-cloudexport_item/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     kentik-cloudexport = {
-      version = "0.1.0"
+      version = ">= 0.2.0"
       source  = "kentik.com/automation/kentik-cloudexport"
     }
   }

--- a/examples/data-sources/kentik-cloudexport_list/provider.tf
+++ b/examples/data-sources/kentik-cloudexport_list/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     kentik-cloudexport = {
-      version = "0.1.0"
+      version = ">= 0.2.0"
       source  = "kentik.com/automation/kentik-cloudexport"
     }
   }

--- a/examples/demo/providers.tf
+++ b/examples/demo/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     kentik-cloudexport = {
-      version = "0.1.0"
+      version = ">= 0.2.0"
       source  = "kentik.com/automation/kentik-cloudexport"
     }
   }

--- a/examples/resources/kentik-cloudexport_item/provider.tf
+++ b/examples/resources/kentik-cloudexport_item/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     kentik-cloudexport = {
-      version = "0.1.0"
+      version = "=> 0.2.0"
       source  = "kentik.com/automation/kentik-cloudexport"
     }
   }


### PR DESCRIPTION
Fixups in Makefile:
- set plugin version based on the newest git tag starting with v
- set OS and ARCH based on the system on which the code is built
- set top-level name for local installation of the plugin to `kentik` in order to make usage of local installation of the plugin easier

Goreleaser:
- enable building darwin/arm64 version of the plugin