### PR TITLE
run.sh functions renamed and moved to utility_functions.sh

### DIFF
--- a/examples/common/provider.tf
+++ b/examples/common/provider.tf
@@ -1,0 +1,11 @@
+# Note: configuration for locally-built provider
+terraform {
+  required_providers {
+    kentik-cloudexport = {
+      version = ">= 0.3.0"
+      source  = "kentik/automation/kentik-cloudexport"
+    }
+  }
+}
+
+provider "kentik-cloudexport" {}

--- a/examples/data-sources/kentik-cloudexport_item/provider.tf
+++ b/examples/data-sources/kentik-cloudexport_item/provider.tf
@@ -1,11 +1,1 @@
-# Note: configuration for locally-built provider
-terraform {
-  required_providers {
-    kentik-cloudexport = {
-      version = ">= 0.3.0"
-      source  = "kentik/automation/kentik-cloudexport"
-    }
-  }
-}
-
-provider "kentik-cloudexport" {}
+../../common/provider.tf

--- a/examples/data-sources/kentik-cloudexport_item/run.sh
+++ b/examples/data-sources/kentik-cloudexport_item/run.sh
@@ -2,7 +2,6 @@
 # The script applies the example Terraform configuration.
 # The provider uses stub Kentik API server by default.
 # Production Kentik API server can be used by passing "production" positional argument to the script.
-# TODO(dfurman): deduplicate with run.sh functions in other examples
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 REPO_DIR=$(cd -- "$SCRIPT_DIR" && cd ../../../ && pwd)
@@ -11,46 +10,4 @@ TEST_API_SERVER_ENDPOINT=${TEST_API_SERVER_ENDPOINT:-"localhost:9955"}
 
 source "$REPO_DIR/tools/utility_functions.sh" || exit 1
 
-function run() {
-    if [[ $1 == "production" ]]; then
-        stage "Running the example using production Kentik API server"
-        warn "Warning: Kentik production resources might be modified"
-        pause
-    else
-        stage "Running the example using test API server"
-        echo "Please make sure that test API server is running at $TEST_API_SERVER_ENDPOINT"
-        set_test_env
-    fi
-
-    check_env
-
-    stage "Build & install plugin"
-    make --directory "$REPO_DIR" install || die
-
-    stage "Terraform init & apply"
-    pushd "$SCRIPT_DIR" > /dev/null || die
-    rm -rf .terraform .terraform.lock.hcl
-
-    terraform init || die
-    terraform apply
-
-    popd > /dev/null || die
-}
-
-function set_test_env() {
-    export KTAPI_URL="http://$TEST_API_SERVER_ENDPOINT"
-    export KTAPI_AUTH_EMAIL="dummy@acme.com"
-    export KTAPI_AUTH_TOKEN="dummy"
-}
-
-function check_env() {
-    if [[ -z "$KTAPI_AUTH_EMAIL" ]]; then
-        die "KTAPI_AUTH_EMAIL env variable must be set to Kentik API account email"
-    fi
-
-    if [[ -z "$KTAPI_AUTH_TOKEN" ]]; then
-        die "KTAPI_AUTH_TOKEN env variable must be set to Kentik API authorization token"
-    fi
-}
-
-run "$1"
+run_examples "$1"

--- a/examples/data-sources/kentik-cloudexport_list/provider.tf
+++ b/examples/data-sources/kentik-cloudexport_list/provider.tf
@@ -1,11 +1,1 @@
-# Note: configuration for locally-built provider
-terraform {
-  required_providers {
-    kentik-cloudexport = {
-      version = ">= 0.3.0"
-      source  = "kentik/automation/kentik-cloudexport"
-    }
-  }
-}
-
-provider "kentik-cloudexport" {}
+../../common/provider.tf

--- a/examples/data-sources/kentik-cloudexport_list/run.sh
+++ b/examples/data-sources/kentik-cloudexport_list/run.sh
@@ -2,7 +2,6 @@
 # The script applies the example Terraform configuration.
 # The provider uses stub Kentik API server by default.
 # Production Kentik API server can be used by passing "production" positional argument to the script.
-# TODO(dfurman): deduplicate with run.sh functions in other examples
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 REPO_DIR=$(cd -- "$SCRIPT_DIR" && cd ../../../ && pwd)
@@ -11,46 +10,4 @@ TEST_API_SERVER_ENDPOINT=${TEST_API_SERVER_ENDPOINT:-"localhost:9955"}
 
 source "$REPO_DIR/tools/utility_functions.sh" || exit 1
 
-function run() {
-    if [[ $1 == "production" ]]; then
-        stage "Running the example using production Kentik API server"
-        warn "Warning: Kentik production resources might be modified"
-        pause
-    else
-        stage "Running the example using test API server"
-        echo "Please make sure that test API server is running at $TEST_API_SERVER_ENDPOINT"
-        set_test_env
-    fi
-
-    check_env
-
-    stage "Build & install plugin"
-    make --directory "$REPO_DIR" install || die
-
-    stage "Terraform init & apply"
-    pushd "$SCRIPT_DIR" > /dev/null || die
-    rm -rf .terraform .terraform.lock.hcl
-
-    terraform init || die
-    terraform apply
-
-    popd > /dev/null || die
-}
-
-function set_test_env() {
-    export KTAPI_URL="http://$TEST_API_SERVER_ENDPOINT"
-    export KTAPI_AUTH_EMAIL="dummy@acme.com"
-    export KTAPI_AUTH_TOKEN="dummy"
-}
-
-function check_env() {
-    if [[ -z "$KTAPI_AUTH_EMAIL" ]]; then
-        die "KTAPI_AUTH_EMAIL env variable must be set to Kentik API account email"
-    fi
-
-    if [[ -z "$KTAPI_AUTH_TOKEN" ]]; then
-        die "KTAPI_AUTH_TOKEN env variable must be set to Kentik API authorization token"
-    fi
-}
-
-run "$1"
+run_examples "$1"

--- a/examples/resources/kentik-cloudexport_item/provider.tf
+++ b/examples/resources/kentik-cloudexport_item/provider.tf
@@ -1,11 +1,1 @@
-# Note: configuration for locally-built provider
-terraform {
-  required_providers {
-    kentik-cloudexport = {
-      version = ">= 0.3.0"
-      source  = "kentik/automation/kentik-cloudexport"
-    }
-  }
-}
-
-provider "kentik-cloudexport" {}
+../../common/provider.tf

--- a/examples/resources/kentik-cloudexport_item/run.sh
+++ b/examples/resources/kentik-cloudexport_item/run.sh
@@ -2,7 +2,6 @@
 # The script applies the example Terraform configuration.
 # The provider uses stub Kentik API server by default.
 # Production Kentik API server can be used by passing "production" positional argument to the script.
-# TODO(dfurman): deduplicate with run.sh functions in other examples
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 REPO_DIR=$(cd -- "$SCRIPT_DIR" && cd ../../../ && pwd)
@@ -11,46 +10,4 @@ TEST_API_SERVER_ENDPOINT=${TEST_API_SERVER_ENDPOINT:-"localhost:9955"}
 
 source "$REPO_DIR/tools/utility_functions.sh" || exit 1
 
-function run() {
-    if [[ $1 == "production" ]]; then
-        stage "Running the example using production Kentik API server"
-        warn "Warning: Kentik production resources might be modified"
-        pause
-    else
-        stage "Running the example using test API server"
-        echo "Please make sure that test API server is running at $TEST_API_SERVER_ENDPOINT"
-        set_test_env
-    fi
-
-    check_env
-
-    stage "Build & install plugin"
-    make --directory "$REPO_DIR" install || die
-
-    stage "Terraform init & apply"
-    pushd "$SCRIPT_DIR" > /dev/null || die
-    rm -rf .terraform .terraform.lock.hcl
-
-    terraform init || die
-    terraform apply
-
-    popd > /dev/null || die
-}
-
-function set_test_env() {
-    export KTAPI_URL="http://$TEST_API_SERVER_ENDPOINT"
-    export KTAPI_AUTH_EMAIL="dummy@acme.com"
-    export KTAPI_AUTH_TOKEN="dummy"
-}
-
-function check_env() {
-    if [[ -z "$KTAPI_AUTH_EMAIL" ]]; then
-        die "KTAPI_AUTH_EMAIL env variable must be set to Kentik API account email"
-    fi
-
-    if [[ -z "$KTAPI_AUTH_TOKEN" ]]; then
-        die "KTAPI_AUTH_TOKEN env variable must be set to Kentik API authorization token"
-    fi
-}
-
-run "$1"
+run_examples "$1"

--- a/tools/utility_functions.sh
+++ b/tools/utility_functions.sh
@@ -49,3 +49,46 @@ function colored_echo() {
         echo "$msg"
     fi
 }
+
+function run_examples() {
+    if [[ $1 == "production" ]]; then
+        stage "Running the example using production Kentik API server"
+        warn "Warning: Kentik production resources might be modified"
+        pause
+    else
+        stage "Running the example using test API server"
+        echo "Please make sure that test API server is running at $TEST_API_SERVER_ENDPOINT"
+        set_test_env_examples
+    fi
+
+    check_env_examples
+
+    stage "Build & install plugin"
+    make --directory "$REPO_DIR" install || die
+
+    stage "Terraform init & apply"
+    pushd "$SCRIPT_DIR" > /dev/null || die
+    rm -rf .terraform .terraform.lock.hcl
+
+    terraform init || die
+    terraform apply
+
+    popd > /dev/null || die
+}
+
+function set_test_env_examples() {
+    export KTAPI_URL="http://$TEST_API_SERVER_ENDPOINT"
+    export KTAPI_AUTH_EMAIL="dummy@acme.com"
+    export KTAPI_AUTH_TOKEN="dummy"
+}
+
+function check_env_examples() {
+    if [[ -z "$KTAPI_AUTH_EMAIL" ]]; then
+        die "KTAPI_AUTH_EMAIL env variable must be set to Kentik API account email"
+    fi
+
+    if [[ -z "$KTAPI_AUTH_TOKEN" ]]; then
+        die "KTAPI_AUTH_TOKEN env variable must be set to Kentik API authorization token"
+    fi
+}
+


### PR DESCRIPTION
KNT-243

run(),set_test_env() and check_env() functions located in examples/../run.sh scripts moved to one file located in tools/utility_functions.sh and renamed (suffix _examples)