### PR TITLE
Fix indentation in lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-          id: go
-          uses: actions/setup-go@v2
-          with:
-            go-version: 1.17
+        id: go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Check if generated documentation is up-to-date


### PR DESCRIPTION
Previous merge included incorrectly indented section in lint.yml, which caused the `lint` workflow to not run at all. This fixes the problem.