### PR TITLE
Prevent possible race condition failure in test API server

### DIFF
--- a/internal/provider/api_server_test.go
+++ b/internal/provider/api_server_test.go
@@ -2,6 +2,7 @@ package provider_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -47,7 +48,9 @@ func (s *testAPIServer) Start() {
 
 	go func() {
 		err = s.server.Serve(l)
-		assert.NoError(s.t, err)
+		if !errors.Is(err, grpc.ErrServerStopped) {
+			assert.NoError(s.t, err)
+		}
 		s.done <- struct{}{}
 	}()
 }


### PR DESCRIPTION
The same fix has been applied to community_sdk_golang before and it
succesfully prevented failure in a corner case (very fast test case).
